### PR TITLE
Expose total hit count from document search

### DIFF
--- a/src/main/java/com/example/DocIx/adapter/out/search/ElasticsearchDocumentSearchAdapter.java
+++ b/src/main/java/com/example/DocIx/adapter/out/search/ElasticsearchDocumentSearchAdapter.java
@@ -3,6 +3,8 @@ package com.example.DocIx.adapter.out.search;
 import com.example.DocIx.domain.model.Document;
 import com.example.DocIx.domain.model.DocumentId;
 import com.example.DocIx.domain.port.out.DocumentSearchEngine;
+import com.example.DocIx.domain.port.out.DocumentSearchEngine.SearchResult;
+import com.example.DocIx.domain.port.out.DocumentSearchEngine.SearchResults;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.IndexRequest;
@@ -71,7 +73,7 @@ public class ElasticsearchDocumentSearchAdapter implements DocumentSearchEngine 
     }
 
     @Override
-    public List<SearchResult> search(String query, int page, int size) {
+    public SearchResults search(String query, int page, int size) {
         try {
             Query searchQuery = Query.of(q -> q
                 .multiMatch(m -> m
@@ -110,7 +112,9 @@ public class ElasticsearchDocumentSearchAdapter implements DocumentSearchEngine 
                 ));
             }
 
-            return results;
+            long totalHits = response.hits().total() != null ? response.hits().total().value() : results.size();
+
+            return new SearchResults(results, totalHits);
 
         } catch (Exception e) {
             throw new SearchEngineException("Failed to search documents", e);

--- a/src/main/java/com/example/DocIx/domain/port/out/DocumentSearchEngine.java
+++ b/src/main/java/com/example/DocIx/domain/port/out/DocumentSearchEngine.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface DocumentSearchEngine {
     void indexDocument(Document document);
     void deleteDocument(DocumentId documentId);
-    List<SearchResult> search(String query, int page, int size);
+    SearchResults search(String query, int page, int size);
     List<String> autocomplete(String query, int maxSuggestions);
 
     class SearchResult {
@@ -28,5 +28,18 @@ public interface DocumentSearchEngine {
         public String getFileName() { return fileName; }
         public String getHighlightedContent() { return highlightedContent; }
         public double getScore() { return score; }
+    }
+
+    class SearchResults {
+        private final List<SearchResult> results;
+        private final long totalHits;
+
+        public SearchResults(List<SearchResult> results, long totalHits) {
+            this.results = results;
+            this.totalHits = totalHits;
+        }
+
+        public List<SearchResult> getResults() { return results; }
+        public long getTotalHits() { return totalHits; }
     }
 }

--- a/src/main/java/com/example/DocIx/domain/service/SearchDocumentService.java
+++ b/src/main/java/com/example/DocIx/domain/service/SearchDocumentService.java
@@ -3,6 +3,7 @@ package com.example.DocIx.domain.service;
 import com.example.DocIx.domain.port.in.SearchDocumentUseCase;
 import com.example.DocIx.domain.port.out.DocumentSearchEngine;
 import com.example.DocIx.domain.port.out.DocumentSearchEngine.SearchResult;
+import com.example.DocIx.domain.port.out.DocumentSearchEngine.SearchResults;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,17 +21,18 @@ public class SearchDocumentService implements SearchDocumentUseCase {
     public SearchResponse searchDocuments(SearchQuery query) {
         validateSearchQuery(query);
 
-        List<SearchResult> results = searchEngine.search(
+        SearchResults searchResults = searchEngine.search(
             query.getQuery(),
             query.getPage(),
             query.getSize()
         );
 
-        // For simplicity, we'll calculate total hits based on current results
-        // In a real implementation, the search engine would return total count
-        long totalHits = results.size() + (query.getPage() * query.getSize());
-
-        return new SearchResponse(results, totalHits, query.getPage(), query.getSize());
+        return new SearchResponse(
+            searchResults.getResults(),
+            searchResults.getTotalHits(),
+            query.getPage(),
+            query.getSize()
+        );
     }
 
     private void validateSearchQuery(SearchQuery query) {


### PR DESCRIPTION
## Summary
- include total hit count in DocumentSearchEngine search results
- propagate total hits from Elasticsearch adapter to service layer

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68aac8a293148324814c409c7cf3e200