### PR TITLE
Add manual RabbitMQ acknowledgments for document processing

### DIFF
--- a/src/main/java/com/example/DocIx/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/DocIx/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package com.example.DocIx.config;
 
+import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
@@ -61,6 +62,7 @@ public class RabbitMQConfig {
         factory.setMessageConverter(messageConverter());
         factory.setConcurrentConsumers(2);
         factory.setMaxConcurrentConsumers(5);
+        factory.setAcknowledgeMode(AcknowledgeMode.MANUAL);
         return factory;
     }
 }


### PR DESCRIPTION
## Summary
- Acknowledge processed messages manually and requeue on shutdown or processing errors
- Configure Rabbit listener container for manual acknowledgment mode

## Testing
- `bash gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68aac89610488324aed89092e2c8eb20